### PR TITLE
Update config-continuous-monitoring's managed policy

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1
+current_version = 3.0.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 3.0.2
+
+**Released**: 2022.06.03
+
+**Commit Delta**: [Change from 3.0.1 release](https://github.com/plus3it/terraform-aws-tardigrade-config/compare/3.0.1...3.0.2)
+
+**Summary**:
+
+*   Uses newer service role policy as prior policy is being deprecated
+
 ### 3.0.1
 
 **Released**: 2021.08.05

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_iam_role_policy_attachment" "this" {
   count = local.create_iam_role ? 1 : 0
 
   role       = aws_iam_role.this[0].name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWS_ConfigRole"
 }
 
 resource "aws_sns_topic" "this" {


### PR DESCRIPTION
Update config-continuous-monitoring's managed policy from AWSConfigRole to AWS_ConfigRole as thee former is being deprecated soon. Reference https://docs.aws.amazon.com/config/latest/developerguide/security-iam-awsmanpol.html